### PR TITLE
Update guides.hanamirb.org link to hanakai.org

### DIFF
--- a/lib/hanami/reloader/commands.rb
+++ b/lib/hanami/reloader/commands.rb
@@ -48,7 +48,7 @@ module Hanami
             group :#{Guardfile.group} do
               guard "puma", port: ENV.fetch("#{Hanami::Port::ENV_VAR}", #{Hanami::Port::DEFAULT}), environment: ENV.fetch("HANAMI_ENV", "development") do
                 # Edit the following regular expression for your needs.
-                # See: https://guides.hanamirb.org/app/code-reloading/
+                # See: https://hanakai.org/learn/hanami/app/code-reloading/
                 watch(%r{^(app|config|lib|slices)([\\/][^\\/]+)*.(rb|erb|haml|slim)$}i)
               end
             end

--- a/spec/unit/hanami/reloader/commands/install_spec.rb
+++ b/spec/unit/hanami/reloader/commands/install_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hanami::Reloader::Commands::Install do
         group :server do
           guard "puma", port: ENV.fetch("HANAMI_PORT", 2300), environment: ENV.fetch("HANAMI_ENV", "development") do
             # Edit the following regular expression for your needs.
-            # See: https://guides.hanamirb.org/app/code-reloading/
+            # See: https://hanakai.org/learn/hanami/app/code-reloading/
             watch(#{matcher})
           end
         end


### PR DESCRIPTION
Related: https://github.com/hanami/hanami-cli/pull/407

The link on Guardfile redirects to [Getting Started - Overview](https://hanakai.org/learn/hanami/v2.3/getting-started) page, so I'm suggesting updating this to the link under hanakai.org/learn